### PR TITLE
shortcode/img Also check for global resources

### DIFF
--- a/layouts/_shortcodes/img.html
+++ b/layouts/_shortcodes/img.html
@@ -13,7 +13,7 @@
 {{- /* Process image */ -}}
 {{- if $process -}}
   {{- $res := false -}}
-  {{- with $.Page.Resources.GetMatch (index $params "src") -}}
+  {{- with or ($.Page.Resources.GetMatch (index $params "src")) (resources.GetMatch (index $params "src")) -}}
     {{- $res = .Process $process -}}
   {{- end -}}
   {{- if $res -}}

--- a/layouts/_shortcodes/img.html
+++ b/layouts/_shortcodes/img.html
@@ -13,7 +13,8 @@
 {{- /* Process image */ -}}
 {{- if $process -}}
   {{- $res := false -}}
-  {{- with or ($.Page.Resources.GetMatch (index $params "src")) (resources.GetMatch (index $params "src")) -}}
+  {{- $src := index $params "src" -}}
+  {{- with or ($.Page.Resources.GetMatch $src) (resources.GetMatch $src) -}}
     {{- $res = .Process $process -}}
   {{- end -}}
   {{- if $res -}}


### PR DESCRIPTION
img didn't take into account global resources (`hugo/assets/`) like the `resource` shortcode does